### PR TITLE
[Feat] 메인 페이지 API 데이터 가공

### DIFF
--- a/my-app/src/componunt/ImageModal.css
+++ b/my-app/src/componunt/ImageModal.css
@@ -1,0 +1,17 @@
+.modal {
+    position: fixed;
+    top:0; left: 0; bottom: 0; right: 0;
+    background: rgba(0, 0, 0, 0.6);
+}
+
+.modal-content{
+    display: flex;
+    justify-content: center;
+}
+
+.modal-content-img {
+    border-radius: 10%;
+    width: 500px;
+    height: 500px;
+    margin-top: 30px;
+}

--- a/my-app/src/componunt/ImageModal.js
+++ b/my-app/src/componunt/ImageModal.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import './ImageModal.css';
+
+function ImageModal({ imageUrl, title, closeModal }) {
+    return (
+        <div className="modal">
+            <div className="modal-content">
+                <img className='modal-content-img' src={imageUrl} alt={title} />
+                <button  onClick={closeModal}>Close</button>
+            </div>
+        </div>
+    );
+}
+
+export default ImageModal;

--- a/my-app/src/page/MainPage.css
+++ b/my-app/src/page/MainPage.css
@@ -1,10 +1,11 @@
 .shopping-item-wrap {
     display: flex;
-    
+    margin-left: 20%;
 }
 
 .shopping-item-img > img{
 
     width: 150px;
+    height: 150px;
     border-radius: 10%;
 }

--- a/my-app/src/page/MainPage.css
+++ b/my-app/src/page/MainPage.css
@@ -1,6 +1,6 @@
 .shopping-item-wrap {
     display: flex;
-    margin-left: 20%;
+    margin-left: 30%;
 }
 
 .shopping-item-img > img{
@@ -8,4 +8,5 @@
     width: 150px;
     height: 150px;
     border-radius: 10%;
+    margin: 10px;
 }

--- a/my-app/src/page/MainPage.js
+++ b/my-app/src/page/MainPage.js
@@ -1,9 +1,12 @@
 import "./MainPage.css"
 import axios from "axios"
 import { useEffect, useState } from "react";
+import ImageModal from '../componunt/ImageModal';
 
 function Main() {
   const [listedData, setlistedData] = useState([]);
+  const [selectedImage, setSelectedImage] = useState(null);
+  const [showModal, setShowModal] = useState(false);
 
   useEffect(() => {
     axios.get('http://cozshopping.codestates-seb.link/api/v1/products')
@@ -16,32 +19,39 @@ function Main() {
         console.error(error);
       });
   }, []);
-  
+
+  const openModal = (imageUrl) => {
+    setSelectedImage(imageUrl);
+    setShowModal(true);
+  };
+
+  const closeModal = () => {
+    setShowModal(false);
+  };
+
   return (
     <main className="main-container">
       <div>
         <p>상품 리스트</p>
         <ul className="shopping-item-wrap">
-          {listedData.filter(item=>(item.image_url)).slice(0,4).map(item => (
+          {listedData.filter(item => (item.image_url)).slice(0, 4).map(item => (
             <li className="shopping-item-img" key={item.id}>
-              <img src={item.image_url} alt={item.title} />
+              <img src={item.image_url} alt={item.title}  onClick={() => openModal(item.image_url)}/>
               <p>{item.title}</p><p>{item.price ? <p>{Number(item.price).toLocaleString()}원</p> : null}</p></li>
           ))}
         </ul>
       </div>
-
-      <div>
-        <p>북마크 리스트</p>
-        <ul className="shopping-item-wrap">
-          {listedData.filter(item=>(item.image_url)).slice(0,4).map(item => (
-            <li className="shopping-item-img" key={item.id}>
-              <img src={item.image_url} alt={item.title} />
-              <p>{item.title}</p></li>
-          ))}
-        </ul>
-      </div>
+      {showModal && (
+        <ImageModal
+          imageUrl={selectedImage}
+          title={selectedImage} // You can pass the actual title of the image here
+          closeModal={closeModal}
+        />
+      )}
     </main>
   );
 }
 
 export default Main;
+
+

--- a/my-app/src/page/MainPage.js
+++ b/my-app/src/page/MainPage.js
@@ -16,7 +16,7 @@ function Main() {
         console.error(error);
       });
   }, []);
-
+  
   return (
     <main className="main-container">
       <div>
@@ -25,13 +25,20 @@ function Main() {
           {listedData.filter(item=>(item.image_url)).slice(0,4).map(item => (
             <li className="shopping-item-img" key={item.id}>
               <img src={item.image_url} alt={item.title} />
-              {item.title}</li>
+              <p>{item.title}</p><p>{item.price ? <p>{Number(item.price).toLocaleString()}원</p> : null}</p></li>
           ))}
         </ul>
       </div>
 
       <div>
         <p>북마크 리스트</p>
+        <ul className="shopping-item-wrap">
+          {listedData.filter(item=>(item.image_url)).slice(0,4).map(item => (
+            <li className="shopping-item-img" key={item.id}>
+              <img src={item.image_url} alt={item.title} />
+              <p>{item.title}</p></li>
+          ))}
+        </ul>
       </div>
     </main>
   );

--- a/my-app/src/page/ShoppingListPage.css
+++ b/my-app/src/page/ShoppingListPage.css
@@ -1,0 +1,3 @@
+.cartagory-container {
+    display: flex;
+}

--- a/my-app/src/page/ShoppingListPage.js
+++ b/my-app/src/page/ShoppingListPage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-function ShoppingListPage() {
+function ShoppingListPage({ listedData }) {
 
 
     return (


### PR DESCRIPTION
어디까지 구현했는지
메인 페이지 API 데이터 가져오기 완료

현재 어딜 구현하고 있는지
가져온 API 데이터 가공 중

앞으로 어딜 구현할 것인지
북 마크 페이지에 데이터를 가져가려고 한다.

집중적으로 코드 리뷰를 받고 싶거나 궁금한 부분

1. API 데이터 가공할 때 어떤 식으로 구현 해야 하는지

  2.상태 끌어올리기로 메인 페이지에서 요청 받은 API 데이터를 북 마크 페이지로 가져가고 싶은데

MainPage.js 에서 import ShoppingListPage from "./ShoppingListPage"; 설정 해주고

```js
 return (
    <main className="main-container">
      <div>
        <p>상품 리스트</p>
        <ul className="shopping-item-wrap">
          {listedData.filter(item=>(item.image_url)).slice(0,4).map(item => (
            <li className="shopping-item-img" key={item.id}>
              <img src={item.image_url} alt={item.title} />
              <p>{item.title}</p><p>{item.price ? <p>{Number(item.price).toLocaleString()}원</p> : null}</p></li>
          ))}
        </ul>
      </div>
      
      <div>
        <ShoppingListPage listedData={listedData} />
      </div>
    </main>
  );
}
```
리턴 문을 작성하면 mainpage에서도 상태를 끌어올린 데이터가 그대로 출력 되는데
어떤 식으로 메인 페이지 에서는 출력이 안되게 하고 쇼핑 페이지에서만 끌어올린 데이터가 출력 될까요
아니면 따로 API 요청을 다시 하는게 좋을까요?